### PR TITLE
Feature/chapter 2.3

### DIFF
--- a/.cursor/rules/supabase.mdc
+++ b/.cursor/rules/supabase.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/supabase.mdc
+++ b/.cursor/rules/supabase.mdc
@@ -3,3 +3,47 @@ description:
 globs:
 alwaysApply: false
 ---
+- **Supabase 및 DB 마이그레이션 관리**
+  - Supabase CLI를 사용하여 데이터베이스 마이그레이션을 생성, 적용, 관리한다.
+    - 마이그레이션 생성:
+      ```bash
+      supabase migration new <name>
+      ```
+    - 마이그레이션 적용:
+      ```bash
+      supabase db push
+      ```
+  - **모든 마이그레이션 파일은 반드시 Git에 커밋한다.**
+    - DB 변경 이력은 코드로 관리하며, 변경 사항은 항상 버전 관리 시스템에 남긴다.
+    - 예시:
+      `supabase/migrations/20240610_create_conversations.sql`
+  - **환경 변수 파일(.env.local 등)은 절대 커밋하지 않는다.**
+    - 환경 변수 파일은 `.gitignore`에 반드시 포함한다.
+    - Service Role Key 등 민감 정보는 서버 환경에서만 사용하고, 클라이언트에 노출하지 않는다.
+  - Supabase 프로젝트 연결 및 환경 변수 설정은 공식 문서와 내부 가이드에 따라 진행한다.
+    - Supabase 대시보드에서 Project URL, anon key, service role key, DB URL을 복사해 환경 변수에 입력한다.
+    - 신규 팀원은 환경설정 문서 순서대로 세팅한다.
+  - **DB 변경 및 마이그레이션은 반드시 코드로 관리하고, 수동으로 대시보드에서 직접 변경하지 않는다.**
+    - 변경 이력 추적 및 협업을 위해 모든 스키마 변경은 마이그레이션 파일로 작성한다.
+
+---
+
+- **DO:**
+  ```bash
+  # 마이그레이션 생성 및 커밋
+  supabase migration new add_messages_table
+  # ... SQL 작성 ...
+  git add supabase/migrations/20240610_add_messages_table.sql
+  git commit -m "feat(db): Add messages table migration"
+  ```
+
+- **DON'T:**
+  - Supabase 대시보드에서 직접 테이블을 생성하고, 마이그레이션 파일을 남기지 않음
+  - .env.local 등 환경 변수 파일을 Git에 커밋
+
+---
+
+**Cross-reference:**
+- 환경 변수 관리 및 보안: [environment-setup.mdc](mdc:.cursor/rules/environment-setup.mdc)
+- 마이그레이션 및 DB 변경 정책: [dev_workflow.mdc](mdc:.cursor/rules/dev_workflow.mdc)
+- 커밋/버전 관리 정책: [cursor_rules.mdc](mdc:.cursor/rules/cursor_rules.mdc)

--- a/docs/setup/database-schema.sql
+++ b/docs/setup/database-schema.sql
@@ -444,3 +444,12 @@ GRANT SELECT ON public.prompt_templates TO anon;
 -- 서비스 역할에게 모든 권한 부여 (서버 사이드 작업용)
 GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+-- 예시: 마이그레이션 롤백 SQL (rollback)
+-- 아래와 같이 -- down 섹션에 작성
+--
+-- down
+DROP TABLE IF EXISTS public.document_conversation_links;
+DROP TABLE IF EXISTS public.documents;
+DROP TABLE IF EXISTS public.messages;
+DROP TABLE IF EXISTS public.conversations;

--- a/supabase/migrations/20250530111412_content-tables.sql
+++ b/supabase/migrations/20250530111412_content-tables.sql
@@ -1,0 +1,446 @@
+-- =============================================================================
+-- AI 서비스 데이터베이스 스키마
+-- Supabase PostgreSQL 스키마 정의
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 확장 기능 활성화
+-- -----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "vector";
+
+-- -----------------------------------------------------------------------------
+-- 사용자 프로필 테이블 (auth.users 확장)
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.user_profiles (
+  id UUID REFERENCES auth.users(id) PRIMARY KEY,
+  email TEXT,
+  full_name TEXT,
+  avatar_url TEXT,
+  subscription_tier TEXT DEFAULT 'free' CHECK (subscription_tier IN ('free', 'pro', 'enterprise')),
+  api_usage_count INTEGER DEFAULT 0,
+  api_usage_limit INTEGER DEFAULT 1000,
+  preferences JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 채팅 세션 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.chat_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL DEFAULT 'New Chat',
+  model_name TEXT DEFAULT 'gpt-4',
+  system_prompt TEXT,
+  temperature DECIMAL(3,2) DEFAULT 0.7,
+  max_tokens INTEGER DEFAULT 4096,
+  is_archived BOOLEAN DEFAULT FALSE,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 메시지 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id UUID REFERENCES public.chat_sessions(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+  content TEXT NOT NULL,
+  token_count INTEGER,
+  model_name TEXT,
+  finish_reason TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 문서 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  filename TEXT NOT NULL,
+  original_filename TEXT NOT NULL,
+  file_url TEXT NOT NULL,
+  file_size INTEGER,
+  content_type TEXT,
+  content_text TEXT,
+  chunk_count INTEGER DEFAULT 0,
+  processing_status TEXT DEFAULT 'pending' CHECK (processing_status IN ('pending', 'processing', 'completed', 'failed')),
+  embedding_status TEXT DEFAULT 'pending' CHECK (embedding_status IN ('pending', 'processing', 'completed', 'failed')),
+  error_message TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 문서 청크 테이블 (RAG용)
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.document_chunks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID REFERENCES public.documents(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  token_count INTEGER,
+  embedding vector(1536), -- OpenAI text-embedding-3-small 차원
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 프롬프트 템플릿 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.prompt_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  template TEXT NOT NULL,
+  variables JSONB DEFAULT '[]',
+  category TEXT DEFAULT 'general',
+  is_public BOOLEAN DEFAULT FALSE,
+  usage_count INTEGER DEFAULT 0,
+  tags TEXT[] DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- API 사용량 로그 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.api_usage_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_id UUID REFERENCES public.chat_sessions(id) ON DELETE SET NULL,
+  endpoint TEXT NOT NULL,
+  model_name TEXT,
+  input_tokens INTEGER DEFAULT 0,
+  output_tokens INTEGER DEFAULT 0,
+  total_tokens INTEGER DEFAULT 0,
+  cost_usd DECIMAL(10,6) DEFAULT 0,
+  response_time_ms INTEGER,
+  status_code INTEGER,
+  error_message TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 캐시 테이블 (프롬프트 캐싱용)
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.prompt_cache (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cache_key TEXT UNIQUE NOT NULL,
+  prompt_hash TEXT NOT NULL,
+  response_content TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  token_count INTEGER,
+  hit_count INTEGER DEFAULT 1,
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 피드백 테이블
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.message_feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id UUID REFERENCES public.messages(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  rating INTEGER CHECK (rating >= 1 AND rating <= 5),
+  feedback_type TEXT CHECK (feedback_type IN ('helpful', 'not_helpful', 'inappropriate', 'inaccurate')),
+  comment TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- -----------------------------------------------------------------------------
+-- 인덱스 생성
+-- -----------------------------------------------------------------------------
+
+-- 채팅 세션 인덱스
+CREATE INDEX idx_chat_sessions_user_id ON public.chat_sessions(user_id);
+CREATE INDEX idx_chat_sessions_created_at ON public.chat_sessions(created_at DESC);
+CREATE INDEX idx_chat_sessions_updated_at ON public.chat_sessions(updated_at DESC);
+
+-- 메시지 인덱스
+CREATE INDEX idx_messages_session_id ON public.messages(session_id);
+CREATE INDEX idx_messages_created_at ON public.messages(created_at DESC);
+CREATE INDEX idx_messages_role ON public.messages(role);
+
+-- 문서 인덱스
+CREATE INDEX idx_documents_user_id ON public.documents(user_id);
+CREATE INDEX idx_documents_processing_status ON public.documents(processing_status);
+CREATE INDEX idx_documents_embedding_status ON public.documents(embedding_status);
+CREATE INDEX idx_documents_created_at ON public.documents(created_at DESC);
+
+-- 문서 청크 인덱스
+CREATE INDEX idx_document_chunks_document_id ON public.document_chunks(document_id);
+CREATE INDEX idx_document_chunks_embedding ON public.document_chunks USING ivfflat (embedding vector_cosine_ops);
+
+-- 프롬프트 템플릿 인덱스
+CREATE INDEX idx_prompt_templates_user_id ON public.prompt_templates(user_id);
+CREATE INDEX idx_prompt_templates_category ON public.prompt_templates(category);
+CREATE INDEX idx_prompt_templates_is_public ON public.prompt_templates(is_public);
+CREATE INDEX idx_prompt_templates_tags ON public.prompt_templates USING GIN(tags);
+
+-- API 사용량 로그 인덱스
+CREATE INDEX idx_api_usage_logs_user_id ON public.api_usage_logs(user_id);
+CREATE INDEX idx_api_usage_logs_created_at ON public.api_usage_logs(created_at DESC);
+CREATE INDEX idx_api_usage_logs_endpoint ON public.api_usage_logs(endpoint);
+
+-- 캐시 인덱스
+CREATE INDEX idx_prompt_cache_cache_key ON public.prompt_cache(cache_key);
+CREATE INDEX idx_prompt_cache_expires_at ON public.prompt_cache(expires_at);
+CREATE INDEX idx_prompt_cache_prompt_hash ON public.prompt_cache(prompt_hash);
+
+-- 피드백 인덱스
+CREATE INDEX idx_message_feedback_message_id ON public.message_feedback(message_id);
+CREATE INDEX idx_message_feedback_user_id ON public.message_feedback(user_id);
+
+-- -----------------------------------------------------------------------------
+-- RLS (Row Level Security) 정책
+-- -----------------------------------------------------------------------------
+
+-- 사용자 프로필 RLS
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own profile" ON public.user_profiles
+  FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "Users can update own profile" ON public.user_profiles
+  FOR UPDATE USING (auth.uid() = id);
+
+-- 채팅 세션 RLS
+ALTER TABLE public.chat_sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own chat sessions" ON public.chat_sessions
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own chat sessions" ON public.chat_sessions
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own chat sessions" ON public.chat_sessions
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own chat sessions" ON public.chat_sessions
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- 메시지 RLS
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view messages from own sessions" ON public.messages
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.chat_sessions
+      WHERE id = messages.session_id AND user_id = auth.uid()
+    )
+  );
+CREATE POLICY "Users can insert messages to own sessions" ON public.messages
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.chat_sessions
+      WHERE id = messages.session_id AND user_id = auth.uid()
+    )
+  );
+
+-- 문서 RLS
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own documents" ON public.documents
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own documents" ON public.documents
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own documents" ON public.documents
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own documents" ON public.documents
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- 문서 청크 RLS
+ALTER TABLE public.document_chunks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view chunks from own documents" ON public.document_chunks
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.documents
+      WHERE id = document_chunks.document_id AND user_id = auth.uid()
+    )
+  );
+CREATE POLICY "Users can insert chunks to own documents" ON public.document_chunks
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.documents
+      WHERE id = document_chunks.document_id AND user_id = auth.uid()
+    )
+  );
+
+-- 프롬프트 템플릿 RLS
+ALTER TABLE public.prompt_templates ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own and public templates" ON public.prompt_templates
+  FOR SELECT USING (auth.uid() = user_id OR is_public = true);
+CREATE POLICY "Users can insert own templates" ON public.prompt_templates
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own templates" ON public.prompt_templates
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own templates" ON public.prompt_templates
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- API 사용량 로그 RLS
+ALTER TABLE public.api_usage_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own usage logs" ON public.api_usage_logs
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Service can insert usage logs" ON public.api_usage_logs
+  FOR INSERT WITH CHECK (true); -- 서비스 레벨에서 삽입
+
+-- 피드백 RLS
+ALTER TABLE public.message_feedback ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own feedback" ON public.message_feedback
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own feedback" ON public.message_feedback
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own feedback" ON public.message_feedback
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- -----------------------------------------------------------------------------
+-- 트리거 함수
+-- -----------------------------------------------------------------------------
+
+-- updated_at 자동 업데이트 함수
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- updated_at 트리거 생성
+CREATE TRIGGER update_user_profiles_updated_at
+  BEFORE UPDATE ON public.user_profiles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_chat_sessions_updated_at
+  BEFORE UPDATE ON public.chat_sessions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_documents_updated_at
+  BEFORE UPDATE ON public.documents
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_prompt_templates_updated_at
+  BEFORE UPDATE ON public.prompt_templates
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_prompt_cache_updated_at
+  BEFORE UPDATE ON public.prompt_cache
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- 사용자 프로필 자동 생성 함수
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.user_profiles (id, email, full_name)
+  VALUES (NEW.id, NEW.email, NEW.raw_user_meta_data->>'full_name');
+  RETURN NEW;
+END;
+$$ language 'plpgsql' SECURITY DEFINER;
+
+-- 새 사용자 등록 시 프로필 자동 생성 트리거
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- 캐시 만료 정리 함수
+CREATE OR REPLACE FUNCTION public.cleanup_expired_cache()
+RETURNS void AS $$
+BEGIN
+  DELETE FROM public.prompt_cache WHERE expires_at < NOW();
+END;
+$$ language 'plpgsql';
+
+-- -----------------------------------------------------------------------------
+-- 유틸리티 함수
+-- -----------------------------------------------------------------------------
+
+-- 벡터 유사도 검색 함수
+CREATE OR REPLACE FUNCTION public.search_similar_chunks(
+  query_embedding vector(1536),
+  match_threshold float DEFAULT 0.8,
+  match_count int DEFAULT 5,
+  user_id_filter uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  document_id uuid,
+  content text,
+  similarity float,
+  metadata jsonb
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    dc.id,
+    dc.document_id,
+    dc.content,
+    1 - (dc.embedding <=> query_embedding) as similarity,
+    dc.metadata
+  FROM public.document_chunks dc
+  JOIN public.documents d ON dc.document_id = d.id
+  WHERE
+    (user_id_filter IS NULL OR d.user_id = user_id_filter)
+    AND 1 - (dc.embedding <=> query_embedding) > match_threshold
+  ORDER BY dc.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ language 'plpgsql';
+
+-- 사용자 API 사용량 확인 함수
+CREATE OR REPLACE FUNCTION public.check_user_api_limit(user_id_param uuid)
+RETURNS boolean AS $$
+DECLARE
+  current_usage integer;
+  usage_limit integer;
+BEGIN
+  SELECT api_usage_count, api_usage_limit
+  INTO current_usage, usage_limit
+  FROM public.user_profiles
+  WHERE id = user_id_param;
+
+  RETURN current_usage < usage_limit;
+END;
+$$ language 'plpgsql';
+
+-- API 사용량 증가 함수
+CREATE OR REPLACE FUNCTION public.increment_api_usage(user_id_param uuid)
+RETURNS void AS $$
+BEGIN
+  UPDATE public.user_profiles
+  SET api_usage_count = api_usage_count + 1
+  WHERE id = user_id_param;
+END;
+$$ language 'plpgsql';
+
+-- -----------------------------------------------------------------------------
+-- 초기 데이터 삽입
+-- -----------------------------------------------------------------------------
+
+-- 기본 프롬프트 템플릿
+INSERT INTO public.prompt_templates (name, description, template, category, is_public, variables) VALUES
+('일반 어시스턴트', '일반적인 AI 어시스턴트 역할', '당신은 도움이 되는 AI 어시스턴트입니다. 사용자의 질문에 정확하고 유용한 답변을 제공해주세요.', 'general', true, '[]'),
+('코딩 도우미', '프로그래밍 관련 질문 답변', '당신은 숙련된 프로그래머입니다. 코딩 문제를 해결하고 최적의 솔루션을 제공해주세요. 언어: {{language}}', 'coding', true, '[{"name": "language", "type": "string", "description": "프로그래밍 언어"}]'),
+('번역가', '다국어 번역 서비스', '당신은 전문 번역가입니다. {{source_lang}}에서 {{target_lang}}로 정확하게 번역해주세요.', 'translation', true, '[{"name": "source_lang", "type": "string", "description": "원본 언어"}, {"name": "target_lang", "type": "string", "description": "번역할 언어"}]'),
+('문서 요약', '긴 문서의 핵심 내용 요약', '다음 문서의 핵심 내용을 {{length}} 형태로 요약해주세요. 중요한 포인트를 놓치지 마세요.', 'analysis', true, '[{"name": "length", "type": "string", "description": "요약 길이 (짧게/보통/자세히)"}]');
+
+-- 스케줄러 설정 (pg_cron 확장이 있는 경우)
+-- SELECT cron.schedule('cleanup-cache', '0 2 * * *', 'SELECT public.cleanup_expired_cache();');
+
+-- -----------------------------------------------------------------------------
+-- 권한 설정
+-- -----------------------------------------------------------------------------
+
+-- 인증된 사용자에게 테이블 접근 권한 부여
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+-- 익명 사용자는 공개 프롬프트 템플릿만 조회 가능
+GRANT SELECT ON public.prompt_templates TO anon;
+
+-- 서비스 역할에게 모든 권한 부여 (서버 사이드 작업용)
+GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;

--- a/supabase/migrations/20250530111412_content-tables.sql
+++ b/supabase/migrations/20250530111412_content-tables.sql
@@ -444,3 +444,9 @@ GRANT SELECT ON public.prompt_templates TO anon;
 -- 서비스 역할에게 모든 권한 부여 (서버 사이드 작업용)
 GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+-- down
+DROP TABLE IF EXISTS public.document_conversation_links;
+DROP TABLE IF EXISTS public.documents;
+DROP TABLE IF EXISTS public.messages;
+DROP TABLE IF EXISTS public.conversations;


### PR DESCRIPTION
## work

- 마이그레이션 파일 작성
    - supabase/migrations/20250530111412_content-tables.sql에 4개 테이블(conversations, messages, documents, document_conversation_links) 생성 SQL이 포함되어 있음
- 마이그레이션 적용
    - ssupabase db push로 실제 DB에 테이블이 생성됨
    - sSupabase 대시보드에서 테이블이 정상적으로 보임
- 롤백 SQL 추가
    - s동일 마이그레이션 파일에 -- down(rollback) SQL이 추가됨
- 문서화
    - sdocs/setup/database-schema.sql에 롤백 예시가 추가됨